### PR TITLE
Improve random number generator for GPU

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -212,6 +212,8 @@ void initCLKernel(){
 	kernel.setArg(4, cl_vbo);
 	kernel.setArg(5, framenumber);
 	kernel.setArg(6, cl_camera);
+	kernel.setArg(7, rand());
+	kernel.setArg(8, rand());
 }
 
 void runKernel(){
@@ -260,7 +262,10 @@ void render(){
 
 	framenumber++;
 	// kernel.setArg(0, cl_spheres);    WORKS even when commented out
-	kernel.setArg(5, WangHash(framenumber));
+	//kernel.setArg(5, WangHash(framenumber));
+	kernel.setArg(5, framenumber);
+	kernel.setArg(7, rand());
+	kernel.setArg(8, rand());
 
 	// build a new camera for each frame on the CPU
 	interactiveCamera->buildRenderCamera(hostRendercam);


### PR DESCRIPTION
Hi Sam,
I noticed you had 'WIP (needs better rand() for DepthOfField)' at the top of this repository.  I experimented with different scenarios and landed on this solution to create random numbers that are pleasing to the eye when used in the createCameraRay() and trace() functions.

You most likely know this, but with my WebGL path tracer I found out the hard way that if you don't change the seed0 and seed1 on every iteration of the bounce loop: 'for (int bounces = 0; bounces < 8; bounces++){...'
then you get rendering artifacts due to the stale nature of the random seeds with each reflection.  This really becomes noticeable when a progressive rendering is made - bright bands appear on the spheres, etc.

I added 2 more arguments to the kernel call, random0 and random1 which are just CPU calls to rand() in C++.  The GPU then takes these and alters them every bounce by the way of adding to itself seed += sin(seed) * big number.  This comes from the famous rand generator 1-liner GPU implementation/approximation that can be found all over the web.  :)

It looks pretty smooth on my machine, needs testing on other platforms to make sure it behaves consistently.  If you can use it great, if not, that's fine too.  I learned a lot by adding this feature to an OpenCL tracer rather than my usual WebGL tracer.  Feel free to change it however you like to suit your tutorial needs.  As always, thanks for the wonderful tutorials Sam!

By the way Happy New Year too!
-Erich