### PR TITLE
Update random seeds on every bounce

### DIFF
--- a/opencl_kernel.cl
+++ b/opencl_kernel.cl
@@ -162,7 +162,7 @@ float3 trace(__constant Sphere* spheres, const Ray* camray, const int sphere_cou
 
 		/* update random number seeds for each bounce */
 		randSeed0 += floor(sin(randSeed0));
-		randSeed1 += floor(sin(randSeed0));
+		randSeed1 += floor(sin(randSeed1));
 		
 		/* if ray misses scene, return background colour */
 		if (!intersect_scene(spheres, &ray, &t, &hitsphere_id, sphere_count))

--- a/opencl_kernel.cl
+++ b/opencl_kernel.cl
@@ -160,11 +160,10 @@ float3 trace(__constant Sphere* spheres, const Ray* camray, const int sphere_cou
 		float t;   /* distance to intersection */
 		int hitsphere_id = 0; /* index of intersected sphere */
 
-		/* update random number seeds for each bounce */ 
-		/*randSeed0 += 1; */ 
-		/*randSeed1 += 345;*/ 
+		/* update random number seeds for each bounce */
+		randSeed0 += floor(sin(randSeed0));
+		randSeed1 += floor(sin(randSeed0));
 		
-
 		/* if ray misses scene, return background colour */
 		if (!intersect_scene(spheres, &ray, &t, &hitsphere_id, sphere_count))
 			return accum_color += mask * (float3)(0.15f, 0.15f, 0.25f);


### PR DESCRIPTION
Hi Sam,
Everything works great, but when the camera is in motion, there are rendering artifacts due to the stale nature of the random seeds on every ray bounce.  This PR alleviates that by randomly adding to the seeds themselves on every bounce.

Now when the camera is in motion, the noise/variance has no distracting patterns and has a gentle soft motion (at least on my laptop, needs to be verified across other devices).  I tried many different updating strategies but this one seems to perform the best so far.  It might be the case that there are better updating algorithms out there for randomness in OpenCL, but this should be operable in the meantime.

Thanks again for your posts!
-Erich
P.S. I can go from 4 samples (your default) down to 2 samples and the noise still looks good.  At 1 sample however, the curtains are pulled back and the math/sin nature of the noise is revealed.  For raw performance reasons, I might need my apps to run at 1 sample per pixel, so in the future I'll see if there are any magic bullets for this noise pattern issue.  Please let me know if you've seen some other solutions out there.